### PR TITLE
Support Private Endpoint with unmanaged Private DNS Zone (Issue #119)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,6 @@
 {
   "image": "mcr.microsoft.com/azterraform:avm-latest",
   "updateRemoteUserUID": true,
-  "containerUser": "1000",
   "runArgs": [],
   "mounts": [],
   "onCreateCommand": "terraform || true",

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The following resources are used by this module:
 - [azurerm_management_lock.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/management_lock) (resource)
 - [azurerm_monitor_diagnostic_setting.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting) (resource)
 - [azurerm_private_endpoint.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
+- [azurerm_private_endpoint.this_unmanaged_dns_zone_groups](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) (resource)
 - [azurerm_private_endpoint_application_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint_application_security_group_association) (resource)
 - [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) (resource)
 - [modtm_telemetry.telemetry](https://registry.terraform.io/providers/Azure/modtm/latest/docs/resources/telemetry) (resource)
@@ -440,6 +441,14 @@ map(object({
 ```
 
 Default: `{}`
+
+### <a name="input_private_endpoints_manage_dns_zone_group"></a> [private\_endpoints\_manage\_dns\_zone\_group](#input\_private\_endpoints\_manage\_dns\_zone\_group)
+
+Description: Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy.
+
+Type: `bool`
+
+Default: `true`
 
 ### <a name="input_public_network_access_enabled"></a> [public\_network\_access\_enabled](#input\_public\_network\_access\_enabled)
 

--- a/avm
+++ b/avm
@@ -48,11 +48,30 @@ if [ -d "${AZURE_CONFIG_DIR}" ]; then
   AZURE_CONFIG_MOUNT="-v ${AZURE_CONFIG_DIR}:/home/runtimeuser/.azure"
 fi
 
-# If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
-if [ -z "${GITHUB_RUN_ID}" ] && [ -z "${NO_COLOR}" ]; then
+# If the host Docker socket exists, mount it into the container so the container can talk to the host docker daemon
+if [ -S /var/run/docker.sock ]; then
+  DOCKER_SOCK_MOUNT="-v /var/run/docker.sock:/var/run/docker.sock"
+fi
+
+# New: allow overriding TUI behavior with PORCH_FORCE_TUI and PORCH_NO_TUI environment variables.
+# - If PORCH_FORCE_TUI is set, force TUI and interactive mode (even in GH Actions).
+# - If PORCH_NO_TUI is set, explicitly disable TUI.
+# - Otherwise, fallback to previous behavior: enable TUI only when not in GitHub Actions and NO_COLOR is not set.
+if [ -n "${PORCH_FORCE_TUI}" ]; then
   TUI="--tui"
   DOCKER_INTERACTIVE="-it"
   export FORCE_COLOR=1
+elif [ -n "${PORCH_NO_TUI}" ]; then
+  # Explicitly disable TUI and interactive flags
+  TUI=""
+  DOCKER_INTERACTIVE=""
+else
+  # If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
+  if [ -z "${GITHUB_RUN_ID}" ] && [ -z "${NO_COLOR}" ]; then
+    TUI="--tui"
+    DOCKER_INTERACTIVE="-it"
+    export FORCE_COLOR=1
+  fi
 fi
 
 # if AVM_PORCH_BASE_URL is set, we want to add it to the make command
@@ -70,6 +89,7 @@ if [ -z "${AVM_IN_CONTAINER}" ]; then
     ${DOCKER_INTERACTIVE} \
     -v "$(pwd)":/src \
     ${AZURE_CONFIG_MOUNT:-} \
+    ${DOCKER_SOCK_MOUNT:-} \
     -e ARM_CLIENT_ID \
     -e ARM_OIDC_REQUEST_TOKEN \
     -e ARM_OIDC_REQUEST_URL \

--- a/avm.ps1
+++ b/avm.ps1
@@ -47,13 +47,29 @@ if (Test-Path $AZURE_CONFIG_DIR) {
   $AZURE_CONFIG_MOUNT_PATH = "${AZURE_CONFIG_DIR}:/home/runtimeuser/.azure"
 }
 
-# If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
+# New: allow overriding TUI behavior with PORCH_FORCE_TUI and PORCH_NO_TUI environment variables.
+# - If PORCH_FORCE_TUI is set, force TUI and interactive mode (even in GH Actions).
+# - If PORCH_NO_TUI is set, explicitly disable TUI.
+# - Otherwise, fallback to previous behavior: enable TUI only when not in GitHub Actions and NO_COLOR is not set.
 $TUI = $null
 $DOCKER_INTERACTIVE = $null
-if (-not $env:GITHUB_RUN_ID -and -not $env:NO_COLOR) {
+if ($env:PORCH_FORCE_TUI -and $env:PORCH_FORCE_TUI -ne "") {
   $TUI = "--tui"
   $DOCKER_INTERACTIVE = "-it"
   $env:FORCE_COLOR = "1"
+}
+elseif ($env:PORCH_NO_TUI -and $env:PORCH_NO_TUI -ne "") {
+  # Explicitly disable TUI and interactive flags
+  $TUI = $null
+  $DOCKER_INTERACTIVE = $null
+}
+else {
+  # If we are not in GitHub Actions and NO_COLOR is not set, we want to use TUI and interactive mode
+  if (-not $env:GITHUB_RUN_ID -and -not $env:NO_COLOR) {
+    $TUI = "--tui"
+    $DOCKER_INTERACTIVE = "-it"
+    $env:FORCE_COLOR = "1"
+  }
 }
 
 # if PORCH_BASE_URL is set, we want to add it to the make command

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -1,6 +1,5 @@
 resource "azurerm_private_endpoint" "this" {
   for_each = { for k, v in var.private_endpoints : k => v if var.private_endpoints_manage_dns_zone_group }
-
   location                      = each.value.location != null ? each.value.location : var.location
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}-${each.key}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
@@ -48,7 +47,6 @@ resource "azurerm_private_endpoint_application_security_group_association" "this
 
 resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
   for_each = { for k, v in var.private_endpoints : k => v if !var.private_endpoints_manage_dns_zone_group }
-
   location                      = each.value.location != null ? each.value.location : var.location
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}-${each.key}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -1,5 +1,6 @@
 resource "azurerm_private_endpoint" "this" {
   for_each = { for k, v in var.private_endpoints : k => v if var.private_endpoints_manage_dns_zone_group }
+
   location                      = each.value.location != null ? each.value.location : var.location
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}-${each.key}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
@@ -47,6 +48,7 @@ resource "azurerm_private_endpoint_application_security_group_association" "this
 
 resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
   for_each = { for k, v in var.private_endpoints : k => v if !var.private_endpoints_manage_dns_zone_group }
+
   location                      = each.value.location != null ? each.value.location : var.location
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}-${each.key}"
   resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name

--- a/main.privateendpoint.tf
+++ b/main.privateendpoint.tf
@@ -1,5 +1,5 @@
 resource "azurerm_private_endpoint" "this" {
-  for_each = var.private_endpoints
+  for_each = { for k, v in var.private_endpoints : k => v if var.private_endpoints_manage_dns_zone_group }
 
   location                      = each.value.location != null ? each.value.location : var.location
   name                          = each.value.name != null ? each.value.name : "pe-${var.name}-${each.key}"
@@ -44,4 +44,36 @@ resource "azurerm_private_endpoint_application_security_group_association" "this
 
   application_security_group_id = each.value.asg_resource_id
   private_endpoint_id           = azurerm_private_endpoint.this[each.value.pe_key].id
+}
+
+resource "azurerm_private_endpoint" "this_unmanaged_dns_zone_groups" {
+  for_each = { for k, v in var.private_endpoints : k => v if !var.private_endpoints_manage_dns_zone_group }
+
+  location                      = each.value.location != null ? each.value.location : var.location
+  name                          = each.value.name != null ? each.value.name : "pe-${var.name}-${each.key}"
+  resource_group_name           = each.value.resource_group_name != null ? each.value.resource_group_name : var.resource_group_name
+  subnet_id                     = each.value.subnet_resource_id
+  custom_network_interface_name = each.value.network_interface_name
+  tags                          = each.value.tags
+
+  private_service_connection {
+    is_manual_connection           = false
+    name                           = each.value.private_service_connection_name != null ? each.value.private_service_connection_name : "pse-${var.name}-${each.key}"
+    private_connection_resource_id = azurerm_databricks_workspace.this.id
+    subresource_names              = [each.value.subresource_name]
+  }
+  dynamic "ip_configuration" {
+    for_each = each.value.ip_configurations
+
+    content {
+      name               = ip_configuration.value.name
+      private_ip_address = ip_configuration.value.private_ip_address
+      member_name        = ip_configuration.value.member_name
+      subresource_name   = ip_configuration.value.subresource_name
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [private_dns_zone_group]
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -443,6 +443,13 @@ variable "private_endpoints" {
   nullable    = false
 }
 
+variable "private_endpoints_manage_dns_zone_group" {
+  type        = bool
+  default     = true
+  description = "Whether to manage private DNS zone groups with this module. If set to false, you must manage private DNS zone groups externally, e.g. using Azure Policy."
+  nullable    = false
+}
+
 variable "public_network_access_enabled" {
   type        = bool
   default     = true


### PR DESCRIPTION
## Description

This pull request allows for the creation of a Private Endpoint with an an unmanaged Private DNS Zone, this means that if you are managing Private DNS Zones through Policy then the configuration is not lost. I have raised an issue for this (#119)

A new Private Endpoint resource has been added to the main.privateendpoint.tf file to support Private Endpoint deployments with unmanaged Private DNS Zone Support. A new variable has been added to toggle which type of Private Endpoint is to be deployed with a default value of true to ensure no breaking changes are introduced.

## Type of Change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] Non-module change (e.g. CI/CD, documentation, etc.)
- [x] Azure Verified Module updates:
  - [ ] Bugfix containing backwards compatible bug fixes
    - [ ] Someone has opened a bug report issue, and I have included "Closes #{bug_report_issue_number}" in the PR description.
    - [ ] The bug was found by the module author, and no one has opened an issue to report it yet.
  - [x] Feature update backwards compatible feature updates.
  - [ ] Breaking changes.
  - [ ] Update to documentation

# Checklist

- [x] I'm sure there are no other open Pull Requests for the same update/change
- [ ] My corresponding pipelines / checks run clean and green without any errors or warnings
- [x] I did run all  [pre-commit](https://azure.github.io/Azure-Verified-Modules/contributing/terraform/terraform-contribution-flow/#5-run-pre-commit-checks) checks

<!--  Please keep up to date with the contribution guide at https://aka.ms/avm/contribute/terraform -->
