### PR TITLE
Feature/remove standard SKU

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ Type: `string`
 
 ### <a name="input_sku"></a> [sku](#input\_sku)
 
-Description:   The 'sku' value must be one of 'standard', 'premium', or 'trial'.  
-  NOTE: Downgrading to a trial sku from a standard or premium sku will force a new resource to be created.
+Description:   The 'sku' value must be one of 'premium', or 'trial'.  
+  NOTE: Changing the sku from 'premium' to 'trial' will force a new resource to be created.
 
 Type: `string`
 

--- a/examples/customer-managed-key/README.md
+++ b/examples/customer-managed-key/README.md
@@ -69,7 +69,7 @@ resource "azurerm_key_vault" "this" {
   # checkov:skip=CKV_AZURE_189: This is a test resource
   name                       = module.naming.key_vault.name_unique
   resource_group_name        = azurerm_resource_group.this.name
-  sku_name                   = "standard"
+  sku_name                   = "premium"
   tenant_id                  = data.azurerm_client_config.this.tenant_id
   enable_rbac_authorization  = true
   purge_protection_enabled   = true

--- a/examples/customer-managed-key/main.tf
+++ b/examples/customer-managed-key/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_key_vault" "this" {
   # checkov:skip=CKV_AZURE_189: This is a test resource
   name                       = module.naming.key_vault.name_unique
   resource_group_name        = azurerm_resource_group.this.name
-  sku_name                   = "standard"
+  sku_name                   = "premium"
   tenant_id                  = data.azurerm_client_config.this.tenant_id
   enable_rbac_authorization  = true
   purge_protection_enabled   = true

--- a/variables.tf
+++ b/variables.tf
@@ -22,13 +22,13 @@ variable "resource_group_name" {
 variable "sku" {
   type        = string
   description = <<DESCRIPTION
-  The 'sku' value must be one of 'standard', 'premium', or 'trial'.
-  NOTE: Downgrading to a trial sku from a standard or premium sku will force a new resource to be created.
+  The 'sku' value must be one of 'premium', or 'trial'.
+  NOTE: Changing the sku from 'premium' to 'trial' will force a new resource to be created.
   DESCRIPTION
 
   validation {
-    condition     = can(regex("^(standard|premium|trial)$", lower(var.sku)))
-    error_message = "The 'sku' value must be one of 'standard', 'premium', or 'trial'."
+    condition     = can(regex("^(premium|trial)$", lower(var.sku)))
+    error_message = "The 'sku' value must be one of 'premium', or 'trial'."
   }
 }
 


### PR DESCRIPTION
This pull request updates the allowed values for the `sku` variable, removing support for the `standard` SKU and ensuring consistency across documentation, validation, and example usage. The changes clarify that only `premium` and `trial` SKUs are now supported.

**SKU restriction and documentation updates:**

* Updated the `sku` variable validation in `variables.tf` to only allow `premium` or `trial` values, and adjusted the error message and description accordingly.
* Updated the `sku` documentation in `README.md` to reflect that only `premium` and `trial` are valid options, and revised the note about resource recreation on SKU changes.

**Example usage updates:**

* Changed the example Key Vault resource in `examples/customer-managed-key/main.tf` to use `sku_name = "premium"` instead of `standard`.
* Made the same update to the example in `examples/customer-managed-key/README.md` for consistency.
[Copilot is generating a summary...]